### PR TITLE
Simplify NETid transition messaging

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -32,9 +32,9 @@
       </a>
     </p>
     <h1>Important – Please Read</h1>
-    <p>ILR’s Salesforce logon process is transitioning to utilizing Cornell’s NetID and password for logon authentication (Single Sign-On).  To that end, logging in to Salesforce by going to the Salesforce.com web address will no longer be available as of Wednesday, February 17, 2021.</p>
+    <p>ILR’s Salesforce authentication process is transitioning to Cornell’s NetID and password. Logging in to Salesforce via <code>login.salesforce.com</code> will no longer work after Wednesday, February 17, 2021.</p>
 
-    <p>If you haven’t already, please begin logging in to Salesforce using ILR’s direct web address – <a href="https://ilroutreach.my.salesforce.com">https://ilroutreach.my.salesforce.com</a> as login access to Salesforce.com will be unavailable in a few short weeks.</p>
+    <p>Please log in to Salesforce using ILR’s direct web address: <a href="https://ilroutreach.my.salesforce.com">https://ilroutreach.my.salesforce.com</a>.</p>
 
     <p>Thank you!</p>
   </div>


### PR DESCRIPTION
Please excuse my forwardness, but when I read the message at https://ilroutreach.my.salesforce.com/, I really wanted to shorten and simplify the text so folks could parse it faster.

Feel free to ignore.

Also, isn't it sort of pointless to place this message at https://ilroutreach.my.salesforce.com since users are already doing the right thing?